### PR TITLE
replaced social icons in header with fontawesome

### DIFF
--- a/config/social.php
+++ b/config/social.php
@@ -3,25 +3,25 @@
 return [
     [
         'title' => 'Twitter',
-        'icon'  => 'ion-logo-twitter',
+        'icon'  => 'fa fa-twitter fa-fw',
         'href'  => 'https://twitter.com/W2DCoin',
     ],
 
     [
         'title' => 'Facebook',
-        'icon'  => 'ion-logo-facebook',
+        'icon'  => 'fa fa-facebook-square fa-fw',
         'href'  => 'https://www.facebook.com/whats2doo/',
     ],
 
     [
         'title' => 'Github',
-        'icon'  => 'ion-logo-github',
+        'icon'  => 'fa fa-github fa-fw',
         'href'  => 'https://github.com/whats2doo',
     ],
 
     [
         'title' => 'Telegram',
-        'icon'  => 'fa fa-telegram',
+        'icon'  => 'fa fa-telegram fa-fw',
         'href'  => 'https://t.me/joinchat/HIpPXA6ND7zyxwCJGH_-Sw',
     ],
 ];

--- a/resources/assets/sass/parts/basic.scss
+++ b/resources/assets/sass/parts/basic.scss
@@ -19,3 +19,11 @@ h3 {
     color: white;
   }
 }
+
+.fa-github {
+  transform: scale(1.1);
+}
+
+.fa-telegram {
+  transform: scale(0.98);
+}

--- a/resources/assets/sass/parts/navbar.scss
+++ b/resources/assets/sass/parts/navbar.scss
@@ -85,8 +85,8 @@ $font-size-social-icons: 22px;
         }
 
         > a {
-          padding-left: 8px !important;
-          padding-right: 8px !important;
+          padding-left: 4px !important;
+          padding-right: 4px !important;
           font-size: $font-size-social-icons !important;
         }
       }


### PR DESCRIPTION
closes #139 

Hab die Icons mit denen von FontAwesome ersetzt. Die anderen wurden ja auch immer erst nach dem pageload geladen, was ich sehr unschön fand. Telegram und Github unterscheiden sich leider auch innerhalb von FontAwesome von der Größe, deshalb die Scale Attribute im CSS